### PR TITLE
redislist_limit option to limit list size by ltrim command

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,6 +20,9 @@ Then fluent automatically loads the plugin installed.
 
       # database number is optional.
       db_number 0        # 0 is default
+
+      # max size of the FIFO list. no limit applied per default.
+      redislist_limit 100
     </match>
 
 == Copyright


### PR DESCRIPTION
(Japanese follows English)

Thank you for giving us the great plugin! This is what I want. The small patch implements an feature to limit maximum size of the list on Redis. The `redislist_limit` option would work great for those who need just to glance a recent records but not to analyze whole data on fluentd. I'm sorry but I couldn't add a test for this as I originally speak Perl and JavaScript.

こんなプラグインが欲しかったです。ありがとうございます。Redis のリスト上の要素数を制限する小さなパッチを書いてみました。この `redislist_limit` オプションは、fluentd の全データの分析をする用途でなくて、最近のデータだけを見たい用途で利用できます。すみません、Ruby は詳しくないので、テストは書けていません。
